### PR TITLE
Atualização das URLs de QR Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/lealhugui/node-dfe#readme",
   "dependencies": {
+    "@types/node": "^12.11.1",
     "cxsd": "^0.1.1",
     "debug": "^4.1.0",
     "lodash": "^4.17.11",

--- a/src/factory/processor/nfeProcessor.ts
+++ b/src/factory/processor/nfeProcessor.ts
@@ -376,19 +376,19 @@ export class NFeProcessor {
 
     private gerarQRCodeNFCeOnline(urlQRCode: string, chave: string, versaoQRCode: string, ambiente: string, idCSC: string, CSC: string) {
         let s = '|';
-        let concat = [chave, versaoQRCode, ambiente, idCSC].join(s);
+        let concat = [chave, versaoQRCode, ambiente, Number(idCSC)].join(s);
         let hash = sha1(concat + CSC).toUpperCase();
 
-        return urlQRCode + concat + s + hash;
+        return urlQRCode + '?p=' + concat + s + hash;
     }
 
     private gerarQRCodeNFCeOffline(urlQRCode: string, chave: string, versaoQRCode: string, ambiente: string, diaEmissao: string, valorTotal:string, digestValue: string, idCSC: string, CSC: string) {
         let s = '|';
-        let hexDigestValue = new Buffer(digestValue).toString('hex');
-        let concat = [chave, versaoQRCode, ambiente, diaEmissao, valorTotal, hexDigestValue, idCSC].join(s);
+        let hexDigestValue = Buffer.from(digestValue).toString('hex');
+        let concat = [chave, versaoQRCode, ambiente, diaEmissao, valorTotal, hexDigestValue, Number(idCSC)].join(s);
         let hash = sha1(concat + CSC).toUpperCase();
 
-        return urlQRCode + concat + s + hash;
+        return urlQRCode + '?p=' + concat + s + hash;
     }
 
     private gerarNFe(documento: NFeDocumento, dadosChave: any) {

--- a/src/factory/webservices/sefazNfce.ts
+++ b/src/factory/webservices/sefazNfce.ts
@@ -3,197 +3,6 @@ import * as Utils from '../utils/utils';
 const servicos = require('../../../servicos.json')
 const autorizadores = require('../../../autorizadores.json')
 
-/*
-const servicos: any = {
-    'autorizacao': {
-        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4',
-        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4/nfeAutorizacaoLote',
-    }, 
-    'retAutorizacao': {
-        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4',
-        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4/nfeRetAutorizacaoLote'
-    }, 
-    'consultarStatusServico': {
-        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4',
-        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4/nfeStatusServicoNF'
-    }
-};
-
-
-const autorizadores = {
-    'AM': {
-        nome: 'Amazonas',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4',
-                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4.asmx?wsdl'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao4',
-                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao4.asmx?wsdl'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4',
-                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4.asmx?wsdl'
-            }
-        }
-    }, 
-    'CE': {
-        nome: 'Ceará',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeAutorizacao4?WSDL',
-                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeAutorizacao4?WSDL'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeRetAutorizacao4?WSDL',
-                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeRetAutorizacao4?WSDL'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL',
-                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL'
-            }
-        }
-    },
-    'GO': {
-        nome: 'Goiás',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl',
-                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeRetAutorizacao4?wsdl',
-                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeRetAutorizacao4?wsdl'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl',
-                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl'
-            }
-        }
-    },
-    'MT': {
-        nome: 'Mato Grosso',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeAutorizacao4',
-                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeAutorizacao4'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeRetAutorizacao4',
-                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeRetAutorizacao4'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4',
-                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4'
-            }
-        }
-    },
-    'MS': {
-        nome: 'Mato Grosso do Sul',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeAutorizacao4',
-                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeAutorizacao4'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeRetAutorizacao4',
-                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeRetAutorizacao4'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeStatusServico4',
-                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeStatusServico4'
-            }
-        }
-    },
-    'MG': {
-        nome: 'Minas Gerais',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4',
-                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeRetAutorizacao4',
-                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeRetAutorizacao4'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4',
-                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4'
-            }
-        }
-    },
-    'PR': {
-        nome: 'Paraná',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeAutorizacao4',
-                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeAutorizacao4'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeRetAutorizacao4',
-                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeRetAutorizacao4'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeStatusServico4',
-                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeStatusServico4'
-            }
-        }
-    }, 
-    'RS': {
-        nome: 'Rio Grande do Sul',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx',
-                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx?wsdl'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx',
-                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx?wsdl'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
-                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx?wsdl'
-            }
-        }
-    }, 
-    'SVRS': {
-        nome: 'SEFAZ Virtual – SVRS',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx',
-                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx',
-                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
-                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx'
-            }
-        }
-    },
-    'SP': {
-        nome: 'São Paulo',
-        servicos: {
-            autorizacao: {
-                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeAutorizacao4.asmx',
-                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeAutorizacao4.asmx'
-            },
-            retAutorizacao: {
-                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeRetAutorizacao4.asmx',
-                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeRetAutorizacao4.asmx'
-            },
-            consultarStatusServico: {
-                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx',
-                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx'
-            }
-        }
-    },
-};
-*/
-
 export abstract class SefazNFCe {
 
     private static getAutorizadorByUF(uf: string): any {
@@ -242,115 +51,115 @@ export abstract class SefazNFCe {
     private static getInfoQRCodeByUF(uf: string, amb: string) {
         if (amb == '1') {
             switch (uf) {
-                case 'AC':
-                    return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaznet.ac.gov.br/nfce/qrcode?' };
-                case 'AL':
-                    return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp' };
-                case 'AP':
-                    return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.ap.gov.br/nfce/nfcep.php' };
-                case 'AM':
-                    return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp?' };
-                case 'BA':
-                    return { urlChave: 'http://www.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx' };
-                case 'CE':
-                    return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html' };
-                case 'DF':
-                    return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode?' };
-                case 'ES':
-                    return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://app.sefaz.es.gov.br/ConsultaNFCe/' };
-                case 'GO':
-                    return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe' };
-                case 'MA':
-                    return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp' };
-                case 'MT':
-                    return { urlChave: 'www.sefaz.mt.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.mt.gov.br/nfce/consultanfce' };
-                case 'MS':
-                    return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode?' };
-                case 'MG':
-                    return { urlChave: 'http://nfce.fazenda.mg.gov.br/portalnfce', urlQRCode: 'https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml' };
-                case 'PA':
-                    return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'https://appnfc.sefa.pa.gov.br/portal/view/consultas/nfce/nfceForm.seam' };
-                case 'PB':
-                    return { urlChave: 'www.receita.pb.gov.br/nfce/consulta', urlQRCode: 'http://www.receita.pb.gov.br/nfce' };
-                case 'PR':
-                    return { urlChave: 'www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode?' };
-                case 'PE':
-                    return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce/consulta' };
-                case 'PI':
-                    return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
-                case 'RJ':
-                    return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode?' };
-                case 'RN':
-                    return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://nfce.set.rn.gov.br/consultarNFCe.aspx' };
-                case 'RS':
-                    return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx?p='};
-                case 'RO':
-                    return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp' };
-                case 'RR':
-                    return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rr.gov.br/nfce/servlet/qrcode' };
-                case 'SP':
-                    return { urlChave: 'https://www.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'https://www.nfce.fazenda.sp.gov.br/qrcode' };
-                case 'SE':
-                    return { urlChave: 'http://www.nfce.se.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.se.gov.br/nfce/qrcode?' };
-                case 'TO':
-                    return { urlChave: 'www.sefaz.to.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.to.gov.br/nfce/qrcode' };
+				case 'AC':
+					return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaznet.ac.gov.br/nfce/qrcode' };
+				case 'AL':
+					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.al.gov.br/nfce/qrcode' };
+				case 'AP':
+					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ap.gov.br/nfce/qrcode' };
+				case 'AM':
+					return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.am.gov.br/nfce/qrcode' };
+				case 'CE':
+					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ce.gov.br/nfce/qrcode' };
+				case 'DF':
+					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode' };
+				case 'ES':
+					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.es.gov.br/nfce/qrcode' };
+				case 'GO':
+					return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.go.gov.br/nfce/qrcode' };
+				case 'MA':
+					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ma.gov.br/nfce/qrcode' };
+				case 'MS':
+					return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+				case 'PA':
+					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'http://www.sefa.pa.gov.br/nfce/qrcode' };
+				case 'PR':
+					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode' };
+				case 'PE':
+					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce/qrcode' };
+				case 'PI':
+					return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
+				case 'RJ':
+					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.rj.gov.br/nfce/qrcode' };
+				case 'RN':
+					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://www.set.rn.gov.br/nfce/qrcode' };
+				case 'RS':
+					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rs.gov.br/nfce/qrcode' };
+				case 'RO':
+					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.sefin.ro.gov.br/nfce/qrcode' };
+				case 'RR':
+					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rr.gov.br/nfce/qrcode' };
+				case 'BA':
+					return { urlChave: 'www.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ba.gov.br/nfce/qrcode' };
+				case 'MG':
+					return { urlChave: 'http://nfce.fazenda.mg.gov.br/portalnfce', urlQRCode: 'http://nfce.fazenda.mg.gov.br/nfce/qrcode' };
+				case 'MT':
+					return { urlChave: 'http://www.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://www.sefaz.mt.gov.br/nfce/qrcode' };
+				case 'PB':
+					return { urlChave: 'www.receita.pb.gov.br/nfce/consulta', urlQRCode: 'http://www.receita.pb.gov.br/nfce/qrcode' };
+				case 'SP':
+					return { urlChave: 'https://www.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'http://www.nfce.fazenda.sp.gov.br/nfce/qrcode' };
+				case 'SE':
+					return { urlChave: 'http://www.nfce.se.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.se.gov.br/nfce/qrcode' };
+				case 'TO':
+					return { urlChave: 'www.sefaz.to.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.to.gov.br/nfce/qrcode' };
                 default:
                     throw new Error('URL do QRCode não encontrada pelo UF ('+uf+') informado.');
             }
         } else {
             switch (uf) {
-                case 'AC':
-                    return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.hml.sefaznet.ac.gov.br/nfce/qrcode?' };
-                case 'AL':
-                    return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp' };
-                case 'AP':
-                    return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.ap.gov.br/nfcehml/nfce.php' };
-                case 'AM':
-                    return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://homnfce.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp?' };
-                case 'BA':
-                    return { urlChave: 'http://hinternet.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx' };
-                case 'CE':
-                    return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html' };
-                case 'DF':
-                    return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode?' };
-                case 'ES':
-                    return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://homologacao.sefaz.es.gov.br/ConsultaNFCe/' };
-                case 'GO':
-                    return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe' };
-                case 'MA':
-                    return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'homologacao.sefaz.ma.gov.br/portal/consultarNFCe.jsp' };
-                case 'MT':
-                    return { urlChave: 'www.sefaz.mt.gov.br/nfce/consulta', urlQRCode: 'http://homologacao.sefaz.mt.gov.br/nfce/consultanfce' };
-                case 'MS':
-                    return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode?' };
-                case 'MG':
-                    return { urlChave: 'http://hnfce.fazenda.mg.gov.br/portalnfce/sistema/consultaarg.xhtml', urlQRCode: 'https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml' };
-                case 'PA':
-                    return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'https://appnfc.sefa.pa.gov.br/portal-homologacao/view/consultas/nfce/nfceForm.seam' };
-                case 'PB':
-                    return { urlChave: 'www.receita.pb.gov.br/nfcehom', urlQRCode: 'http://www.receita.pb.gov.br/nfcehom' };
-                case 'PR':
-                    return { urlChave: 'www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode?' };
-                case 'PE':
-                    return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfcehomolog.sefaz.pe.gov.br/nfce/consulta' };
-                case 'PI':
-                    return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
-                case 'RJ':
-                    return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode?' };
-                case 'RN':
-                    return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://hom.nfce.set.rn.gov.br/consultarNFCe.aspx' };
-                case 'RS':
-                    return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx?p='};
-                case 'RO':
-                    return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp' };
-                case 'RR':
-                    return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://200.174.88.103:8080/nfce/servlet/qrcode' };
-                case 'SP':
-                    return { urlChave: 'https://www.homologacao.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'https://www.homologacao.nfce.fazenda.sp.gov.br/qrcode' };
-                case 'SE':
-                    return { urlChave: 'http://www.hom.nfe.se.gov.br/nfce/consulta', urlQRCode: 'http://www.hom.nfe.se.gov.br/nfce/qrcode?' };
-                case 'TO':
-                    return { urlChave: 'www.sefaz.to.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.to.gov.br/nfce/qrcode' };
+				case 'AC':
+					return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaznet.ac.gov.br/nfce/qrcode' };
+				case 'AL':
+					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.al.gov.br/nfce/qrcode' };
+				case 'AP':
+					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ap.gov.br/nfce/qrcode' };
+				case 'AM':
+					return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.am.gov.br/nfce/qrcode' };
+				case 'CE':
+					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ce.gov.br/nfce/qrcode' };
+				case 'DF':
+					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode' };
+				case 'ES':
+					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.es.gov.br/nfce/qrcode' };
+				case 'GO':
+					return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.go.gov.br/nfce/qrcode' };
+				case 'MA':
+					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ma.gov.br/nfce/qrcode' };
+				case 'MS':
+					return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+				case 'PA':
+					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'http://www.sefa.pa.gov.br/nfce/qrcode' };
+				case 'PR':
+					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode' };
+				case 'PE':
+					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce/qrcode' };
+				case 'PI':
+					return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
+				case 'RJ':
+					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.rj.gov.br/nfce/qrcode' };
+				case 'RN':
+					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://www.set.rn.gov.br/nfce/qrcode' };
+				case 'RS':
+					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rs.gov.br/nfce/qrcode' };
+				case 'RO':
+					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.sefin.ro.gov.br/nfce/qrcode' };
+				case 'RR':
+					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rr.gov.br/nfce/qrcode' };
+				case 'BA':
+					return { urlChave: 'http://hinternet.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://hinternet.sefaz.ba.gov.br/nfce/qrcode' };
+				case 'MG':
+					return { urlChave: 'http://hnfce.fazenda.mg.gov.br/portalnfce/', urlQRCode: 'http://hnfce.fazenda.mg.gov.br/nfce/qrcode' };
+				case 'MT':
+					return { urlChave: 'http://homologacao.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://homologacao.sefaz.mt.gov.br/nfce/qrcode' };
+				case 'PB':
+					return { urlChave: 'www.receita.pb.gov.br/nfcehom', urlQRCode: 'http://www.receita.pb.gov.br/nfce/qrcode' };
+				case 'SP':
+					return { urlChave: 'https://www.homologacao.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'http://www.homologacao.nfce.fazenda.sp.gov.br/nfce/qrcode' };
+				case 'SE':
+					return { urlChave: 'http://www.hom.nfe.se.gov.br/nfce/consulta', urlQRCode: 'http://www.hom.nfe.se.gov.br/nfce/qrcode' };
+				case 'TO':
+					return { urlChave: 'http://homologacao.sefaz.to.gov.br/nfce/consulta.jsf', urlQRCode: 'http://homologacao.sefaz.to.gov.br/nfce/qrcode' };
                 default:
                     throw new Error('URL do QRCode não encontrada pelo UF ('+uf+') informado.');
             }

--- a/src/factory/webservices/sefazNfce.ts
+++ b/src/factory/webservices/sefazNfce.ts
@@ -3,6 +3,197 @@ import * as Utils from '../utils/utils';
 const servicos = require('../../../servicos.json')
 const autorizadores = require('../../../autorizadores.json')
 
+/*
+const servicos: any = {
+    'autorizacao': {
+        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4',
+        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4/nfeAutorizacaoLote',
+    },
+    'retAutorizacao': {
+        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4',
+        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4/nfeRetAutorizacaoLote'
+    },
+    'consultarStatusServico': {
+        method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4',
+        action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4/nfeStatusServicoNF'
+    }
+};
+
+
+const autorizadores = {
+    'AM': {
+        nome: 'Amazonas',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4',
+                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4.asmx?wsdl'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao4',
+                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao4.asmx?wsdl'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4',
+                url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4.asmx?wsdl'
+            }
+        }
+    },
+    'CE': {
+        nome: 'Ceará',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeAutorizacao4?WSDL',
+                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeAutorizacao4?WSDL'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeRetAutorizacao4?WSDL',
+                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeRetAutorizacao4?WSDL'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL',
+                url_homologacao: 'https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL'
+            }
+        }
+    },
+    'GO': {
+        nome: 'Goiás',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl',
+                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeRetAutorizacao4?wsdl',
+                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeRetAutorizacao4?wsdl'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl',
+                url_homologacao: 'https://homolog.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl'
+            }
+        }
+    },
+    'MT': {
+        nome: 'Mato Grosso',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeAutorizacao4',
+                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeAutorizacao4'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeRetAutorizacao4',
+                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeRetAutorizacao4'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4',
+                url_homologacao: 'https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4'
+            }
+        }
+    },
+    'MS': {
+        nome: 'Mato Grosso do Sul',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeAutorizacao4',
+                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeAutorizacao4'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeRetAutorizacao4',
+                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeRetAutorizacao4'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefaz.ms.gov.br/ws/NFeStatusServico4',
+                url_homologacao: 'https://hom.nfce.sefaz.ms.gov.br/ws/NFeStatusServico4'
+            }
+        }
+    },
+    'MG': {
+        nome: 'Minas Gerais',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4',
+                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeRetAutorizacao4',
+                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeRetAutorizacao4'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4',
+                url_homologacao: 'https://hnfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4'
+            }
+        }
+    },
+    'PR': {
+        nome: 'Paraná',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeAutorizacao4',
+                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeAutorizacao4'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeRetAutorizacao4',
+                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeRetAutorizacao4'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefa.pr.gov.br/nfce/NFeStatusServico4',
+                url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeStatusServico4'
+            }
+        }
+    },
+    'RS': {
+        nome: 'Rio Grande do Sul',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx',
+                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx?wsdl'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx',
+                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx?wsdl'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
+                url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx?wsdl'
+            }
+        }
+    },
+    'SVRS': {
+        nome: 'SEFAZ Virtual – SVRS',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx',
+                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx',
+                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeRetAutorizacao/NFeRetAutorizacao4.asmx'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
+                url_homologacao: 'https://nfce-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx'
+            }
+        }
+    },
+    'SP': {
+        nome: 'São Paulo',
+        servicos: {
+            autorizacao: {
+                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeAutorizacao4.asmx',
+                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeAutorizacao4.asmx'
+            },
+            retAutorizacao: {
+                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeRetAutorizacao4.asmx',
+                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeRetAutorizacao4.asmx'
+            },
+            consultarStatusServico: {
+                url_producao: 'https://nfce.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx',
+                url_homologacao: 'https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx'
+            }
+        }
+    },
+};
+*/
+
 export abstract class SefazNFCe {
 
     private static getAutorizadorByUF(uf: string): any {

--- a/src/factory/webservices/sefazNfce.ts
+++ b/src/factory/webservices/sefazNfce.ts
@@ -245,53 +245,53 @@ export abstract class SefazNFCe {
 				case 'AC':
 					return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaznet.ac.gov.br/nfce/qrcode' };
 				case 'AL':
-					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.al.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp' };
 				case 'AP':
-					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ap.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.ap.gov.br/nfce/nfcep.php' };
 				case 'AM':
-					return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.am.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp' };
+				case 'BA':
+					return { urlChave: 'www.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://nfe.sefaz.ba.gov.br/servicos/nfce/modulos/geral/NFCEC_consulta_chave_acesso.aspx' };
 				case 'CE':
-					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ce.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html' };
 				case 'DF':
-					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://dec.fazenda.df.gov.br/ConsultarNFCe.aspx' };
 				case 'ES':
-					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.es.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://app.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx' };
 				case 'GO':
-					return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.go.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe' };
 				case 'MA':
-					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ma.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp' };
+				case 'MG':
+					return { urlChave: 'http://nfce.fazenda.mg.gov.br/portalnfce', urlQRCode: 'https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml' };
 				case 'MS':
-					return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+					return { urlChave: 'http://www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+				case 'MT':
+					return { urlChave: 'http://www.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://www.sefaz.mt.gov.br/nfce/consultanfce' };
 				case 'PA':
-					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'http://www.sefa.pa.gov.br/nfce/qrcode' };
-				case 'PR':
-					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'https://appnfc.sefa.pa.gov.br/portal/view/consultas/nfce/nfceForm.seam' };
+				case 'PB':
+					return { urlChave: 'www.receita.pb.gov.br/nfce/consulta', urlQRCode: 'http://www.receita.pb.gov.br/nfce' };
 				case 'PE':
-					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce/qrcode' };
+					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce-web/consultarNFCe' };
 				case 'PI':
 					return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
+				case 'PR':
+					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode/' };
 				case 'RJ':
-					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.rj.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode' };
 				case 'RN':
-					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://www.set.rn.gov.br/nfce/qrcode' };
-				case 'RS':
-					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rs.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://nfce.set.rn.gov.br/consultarNFCe.aspx' };
 				case 'RO':
-					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.sefin.ro.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp' };
+				case 'RS':
+					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx' };
 				case 'RR':
-					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rr.gov.br/nfce/qrcode' };
-				case 'BA':
-					return { urlChave: 'www.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ba.gov.br/nfce/qrcode' };
-				case 'MG':
-					return { urlChave: 'http://nfce.fazenda.mg.gov.br/portalnfce', urlQRCode: 'http://nfce.fazenda.mg.gov.br/nfce/qrcode' };
-				case 'MT':
-					return { urlChave: 'http://www.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://www.sefaz.mt.gov.br/nfce/qrcode' };
-				case 'PB':
-					return { urlChave: 'www.receita.pb.gov.br/nfce/consulta', urlQRCode: 'http://www.receita.pb.gov.br/nfce/qrcode' };
-				case 'SP':
-					return { urlChave: 'https://www.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'http://www.nfce.fazenda.sp.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rr.gov.br/nfce/servlet/qrcode' };
 				case 'SE':
-					return { urlChave: 'http://www.nfce.se.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.se.gov.br/nfce/qrcode' };
+					return { urlChave: 'http://www.nfce.se.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.se.gov.br/portal/consultarNFCe.jsp' };
+				case 'SP':
+					return { urlChave: 'https://www.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'https://www.nfce.fazenda.sp.gov.br/qrcode' };
 				case 'TO':
 					return { urlChave: 'www.sefaz.to.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.to.gov.br/nfce/qrcode' };
                 default:
@@ -300,55 +300,55 @@ export abstract class SefazNFCe {
         } else {
             switch (uf) {
 				case 'AC':
-					return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaznet.ac.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaznet.ac.gov.br/nfce/consulta', urlQRCode: 'http://hml.sefaznet.ac.gov.br/nfce/qrcode' };
 				case 'AL':
-					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.al.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.al.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp' };
 				case 'AP':
-					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ap.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ap.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.ap.gov.br/nfcehml/nfce.php' };
 				case 'AM':
-					return { urlChave: 'www.sefaz.am.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.am.gov.br/nfce/qrcode' };
+					return { urlChave: 'https://sistemas.sefaz.am.gov.br/nfceweb-hom/formConsulta.do', urlQRCode: 'https://sistemas.sefaz.am.gov.br/nfceweb-hom/consultarNFCe.jsp' };
+				case 'BA':
+					return { urlChave: 'http://hinternet.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://hnfe.sefaz.ba.gov.br/servicos/nfce/modulos/geral/NFCEC_consulta_chave_acesso.aspx' };
 				case 'CE':
-					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ce.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ce.gov.br/nfce/consulta', urlQRCode: 'http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html' };
 				case 'DF':
-					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.df.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.fazenda.df.gov.br/nfce/consulta', urlQRCode: 'http://dec.fazenda.df.gov.br/ConsultarNFCe.aspx' };
 				case 'ES':
-					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.es.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.es.gov.br/nfce/consulta', urlQRCode: 'http://homologacao.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx' };
 				case 'GO':
-					return { urlChave: 'www.sefaz.go.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.go.gov.br/nfce/qrcode' };
+					return { urlChave: 'http://www.nfce.go.gov.br/post/ver/214413/consulta-nfc-e-homologacao', urlQRCode: 'http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe' };
 				case 'MA':
-					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.ma.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.ma.gov.br/nfce/consulta', urlQRCode: 'http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp' };
+				case 'MG':
+					return { urlChave: 'http://hnfce.fazenda.mg.gov.br/portalnfce', urlQRCode: 'https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml' };
 				case 'MS':
-					return { urlChave: 'www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+					return { urlChave: 'http://www.dfe.ms.gov.br/nfce/consulta', urlQRCode: 'http://www.dfe.ms.gov.br/nfce/qrcode' };
+				case 'MT':
+					return { urlChave: 'http://homologacao.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://homologacao.sefaz.mt.gov.br/nfce/consultanfce' };
 				case 'PA':
-					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'http://www.sefa.pa.gov.br/nfce/qrcode' };
-				case 'PR':
-					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefa.pa.gov.br/nfce/consulta', urlQRCode: 'https://appnfc.sefa.pa.gov.br/portal-homologacao/view/consultas/nfce/nfceForm.seam' };
+				case 'PB':
+					return { urlChave: 'www.receita.pb.gov.br/nfcehom', urlQRCode: 'http://www.receita.pb.gov.br/nfcehom' };
 				case 'PE':
-					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfce.sefaz.pe.gov.br/nfce/qrcode' };
+					return { urlChave: 'nfce.sefaz.pe.gov.br/nfce/consulta', urlQRCode: 'http://nfcehomolog.sefaz.pe.gov.br/nfce-web/consultarNFCe' };
 				case 'PI':
 					return { urlChave: 'www.sefaz.pi.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.pi.gov.br/nfce/qrcode' };
+				case 'PR':
+					return { urlChave: 'http://www.fazenda.pr.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.pr.gov.br/nfce/qrcode/' };
 				case 'RJ':
-					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www.fazenda.rj.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.fazenda.rj.gov.br/nfce/consulta', urlQRCode: 'http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode' };
 				case 'RN':
-					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://www.set.rn.gov.br/nfce/qrcode' };
-				case 'RS':
-					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rs.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.set.rn.gov.br/nfce/consulta', urlQRCode: 'http://hom.nfce.set.rn.gov.br/consultarNFCe.aspx' };
 				case 'RO':
-					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.sefin.ro.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefin.ro.gov.br/nfce/consulta', urlQRCode: 'http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp' };
+				case 'RS':
+					return { urlChave: 'www.sefaz.rs.gov.br/nfce/consulta', urlQRCode: 'https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx' };
 				case 'RR':
-					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://www.sefaz.rr.gov.br/nfce/qrcode' };
-				case 'BA':
-					return { urlChave: 'http://hinternet.sefaz.ba.gov.br/nfce/consulta', urlQRCode: 'http://hinternet.sefaz.ba.gov.br/nfce/qrcode' };
-				case 'MG':
-					return { urlChave: 'http://hnfce.fazenda.mg.gov.br/portalnfce/', urlQRCode: 'http://hnfce.fazenda.mg.gov.br/nfce/qrcode' };
-				case 'MT':
-					return { urlChave: 'http://homologacao.sefaz.mt.gov.br/nfce/consultanfce', urlQRCode: 'http://homologacao.sefaz.mt.gov.br/nfce/qrcode' };
-				case 'PB':
-					return { urlChave: 'www.receita.pb.gov.br/nfcehom', urlQRCode: 'http://www.receita.pb.gov.br/nfce/qrcode' };
-				case 'SP':
-					return { urlChave: 'https://www.homologacao.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'http://www.homologacao.nfce.fazenda.sp.gov.br/nfce/qrcode' };
+					return { urlChave: 'www.sefaz.rr.gov.br/nfce/consulta', urlQRCode: 'http://200.174.88.103:8080/nfce/servlet/qrcode' };
 				case 'SE':
-					return { urlChave: 'http://www.hom.nfe.se.gov.br/nfce/consulta', urlQRCode: 'http://www.hom.nfe.se.gov.br/nfce/qrcode' };
+					return { urlChave: 'http://www.hom.nfe.se.gov.br/nfce/consulta', urlQRCode: 'http://www.hom.nfe.se.gov.br/portal/consultarNFCe.jsp' };
+				case 'SP':
+					return { urlChave: 'https://www.homologacao.nfce.fazenda.sp.gov.br/consulta', urlQRCode: 'https://www.homologacao.nfce.fazenda.sp.gov.br/qrcode' };
 				case 'TO':
 					return { urlChave: 'http://homologacao.sefaz.to.gov.br/nfce/consulta.jsf', urlQRCode: 'http://homologacao.sefaz.to.gov.br/nfce/qrcode' };
                 default:

--- a/src/factory/webservices/sefazNfce.ts
+++ b/src/factory/webservices/sefazNfce.ts
@@ -8,11 +8,11 @@ const servicos: any = {
     'autorizacao': {
         method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4',
         action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeAutorizacao4/nfeAutorizacaoLote',
-    },
+    }, 
     'retAutorizacao': {
         method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4',
         action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeRetAutorizacao4/nfeRetAutorizacaoLote'
-    },
+    }, 
     'consultarStatusServico': {
         method: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4',
         action: 'http://www.portalfiscal.inf.br/nfe/wsdl/NFeStatusServico4/nfeStatusServicoNF'
@@ -37,7 +37,7 @@ const autorizadores = {
                 url_homologacao: 'https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4.asmx?wsdl'
             }
         }
-    },
+    }, 
     'CE': {
         nome: 'Ceará',
         servicos: {
@@ -139,7 +139,7 @@ const autorizadores = {
                 url_homologacao: 'https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeStatusServico4'
             }
         }
-    },
+    }, 
     'RS': {
         nome: 'Rio Grande do Sul',
         servicos: {
@@ -156,7 +156,7 @@ const autorizadores = {
                 url_homologacao: 'https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx?wsdl'
             }
         }
-    },
+    }, 
     'SVRS': {
         nome: 'SEFAZ Virtual – SVRS',
         servicos: {


### PR DESCRIPTION
Atualização das URLs de QR Code do NFCe

Obs. No formato antigo retornava erro na emissão de notas para o DF no que diz respeito à URL do QR Code. O erro foi solucionado com a atualização das URLs.