### PR TITLE
Revert "Retira a necessidade de um arquivo .key."

### DIFF
--- a/src/factory/signature.ts
+++ b/src/factory/signature.ts
@@ -6,7 +6,7 @@ export abstract class Signature {
   public static signXml(xml: string, tag: string, certificado: any) {
     let sig = new SignedXml();
     sig.addReference("//*[local-name(.)='"+tag+"']","","","","","", true);
-    sig.signingKey = certificado.pem;
+    sig.signingKey = certificado.key;
     sig.computeSignature(xml);
     return sig.getSignedXml();
   }
@@ -34,7 +34,7 @@ export abstract class Signature {
     let sig = new SignedXml();
 
     sig.addReference("//*[local-name(.)='"+tag+"']", transforms, "", "", "", "", false);
-    sig.signingKey = certificado.pem;
+    sig.signingKey = certificado.key;
     sig.canonicalizationAlgorithm = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
     sig.keyInfoProvider = infoProvider(certificado.pem);
     sig.computeSignature(xml);

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ const signUtils = require('./lib/factory/signature');
 const XmlHelper = require('./lib/factory/xmlHelper');
 
 let cert = {
+    key: fs.readFileSync('C:\\cert\\newKey.key'),
     pem: fs.readFileSync('C:\\cert\\test.pem'),
     pfx: fs.readFileSync('C:\\cert\\certificado.pfx'),
     password: fs.readFileSync('C:\\cert\\senha.txt')


### PR DESCRIPTION
Reverts lealhugui/node-dfe#11

Revertendo pois é necessário a chave privada para assinatura. Após o merge começou a ocorrer erros. 