### PR TITLE
Ajustes para compatibilizar chamadas de inutilização para Nfce

### DIFF
--- a/autorizadores.json
+++ b/autorizadores.json
@@ -13,6 +13,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4",
                 "url_homologacao": "https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeStatusServico4.asmx?wsdl"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfce.sefaz.am.gov.br/nfce-services/services/NFeInutilizacao4",
+                "url_homologacao": "https://homnfce.sefaz.am.gov.br/nfce-services/services/NFeInutilizacao4.asmx?wsdl"
             }
         }
     },
@@ -30,6 +34,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL",
                 "url_homologacao": "https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeStatusServico4?WSDL"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfce.sefaz.ce.gov.br/nfce4/services/NFeInutilizacao4?WSDL",
+                "url_homologacao": "https://nfceh.sefaz.ce.gov.br/nfce4/services/NFeInutilizacao4?WSDL"
             }
         }
     },
@@ -47,6 +55,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl",
                 "url_homologacao": "https://homolog.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.sefaz.go.gov.br/nfe/services/NFeInutilizacao4",
+                "url_homologacao": "https://homolog.sefaz.go.gov.br/nfe/services/Nfeinutilizacao4.asmx"
             }
         }
     },
@@ -64,6 +76,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4",
                 "url_homologacao": "https://homologacao.sefaz.mt.gov.br/nfcews/services/NfeStatusServico4"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.sefaz.mt.gov.br/nfews/v2/services/NfeInutilizacao4",
+                "url_homologacao": "https://homologacao.sefaz.mt.gov.br/nfcews/services/Nfeinutilizacao4.asmx"
             }
         }
     },
@@ -81,6 +97,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefaz.ms.gov.br/ws/NFeStatusServico4",
                 "url_homologacao": "https://hom.nfce.sefaz.ms.gov.br/ws/NFeStatusServico4"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.sefaz.ms.gov.br/ws/NFeInutilizacao4",
+                "url_homologacao": "https://hom.nfce.sefaz.ms.gov.br/ws/Nfeinutilizacao4.asmx"
             }
         }
     },
@@ -98,6 +118,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4",
                 "url_homologacao": "https://hnfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.fazenda.mg.gov.br/nfe2/services/NFeInutilizacao4",
+                "url_homologacao": "https://hnfce.fazenda.mg.gov.br/nfce/services/Nfeinutilizacao4.asmx"
             }
         }
     },
@@ -115,6 +139,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefa.pr.gov.br/nfce/NFeStatusServico4",
                 "url_homologacao": "https://homologacao.nfce.sefa.pr.gov.br/nfce/NFeStatusServico4"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.sefa.pr.gov.br/nfe/NFeInutilizacao4",
+                "url_homologacao": "https://homologacao.nfce.sefa.pr.gov.br/nfce/Nfeinutilizacao4.asmx"
             }
         }
     },
@@ -132,6 +160,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
                 "url_homologacao": "https://nfce-homologacao.sefazrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx?wsdl"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.sefazrs.rs.gov.br/ws/nfeinutilizacao/nfeinutilizacao4.asmx",
+                "url_homologacao": "https://nfce-homologacao.sefazrs.rs.gov.br/ws/nfeinutilizacao/nfeinutilizacao4.asmx"
             }
         }
     },

--- a/autorizadores.json
+++ b/autorizadores.json
@@ -149,6 +149,10 @@
             "consultarStatusServico": {
                 "url_producao": "https://nfce.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx",
                 "url_homologacao": "https://nfce-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx"
+            },
+            "inutilizacao": {
+                "url_producao": "https://nfe.svrs.rs.gov.br/ws/nfeinutilizacao/nfeinutilizacao4.asmx",
+                "url_homologacao": "https://nfce-homologacao.svrs.rs.gov.br/ws/nfeinutilizacao/nfeinutilizacao4.asmx"
             }
         }
     },

--- a/lib/factory/processor/enviaProcessor.js
+++ b/lib/factory/processor/enviaProcessor.js
@@ -430,14 +430,14 @@ class EnviaProcessor {
     getDetImposto(imposto, modelo, cfop) {
         let detImposto = {
             vTotTrib: imposto.valorAproximadoTributos,
-            ICMS: [this.getImpostoIcms(imposto.icms)],
-            PIS: [this.getImpostoPIS(imposto.pis, modelo)],
-            COFINS: [this.getImpostoCOFINS(imposto.cofins, modelo)],
-            PISST: [this.getImpostoPISST(imposto.pisst)],
-            COFINSST: [this.getImpostoCOFINSST(imposto.cofinsst)],
-            IPI: [this.getImpostoIPI(imposto.ipi, modelo)],
-            II: [this.getImpostoII(imposto.ii, cfop)],
-            ICMSUFDest: [this.getIcmsUfDest(imposto.icmsUfDest)],
+            ICMS: imposto.icms ? [this.getImpostoIcms(imposto.icms)] : [],
+            PIS: imposto.pis ? [this.getImpostoPIS(imposto.pis, modelo)] : [],
+            COFINS: imposto.cofins ? [this.getImpostoCOFINS(imposto.cofins, modelo)] : [],
+            PISST: imposto.pisst ? [this.getImpostoPISST(imposto.pisst)] : [],
+            COFINSST: imposto.cofinsst ? [this.getImpostoCOFINSST(imposto.cofinsst)] : [],
+            IPI: imposto.ipi ? [this.getImpostoIPI(imposto.ipi, modelo)] : [],
+            II: imposto.ii ? [this.getImpostoII(imposto.ii, cfop)] : [],
+            ICMSUFDest: imposto.icmsUfDest ? [this.getIcmsUfDest(imposto.icmsUfDest)] : [],
             ISSQN: '',
         };
         return detImposto;

--- a/lib/factory/processor/inutilizaProcessor.js
+++ b/lib/factory/processor/inutilizaProcessor.js
@@ -43,13 +43,13 @@ class InutilizaProcessor {
             soapInutilizacao = Sefaz.getSoapInfo(empresa.endereco.uf, ambiente, nfe_1.ServicosSefaz.inutilizacao);
             const xml = this.gerarXml(dados);
             result = await this.transmitirXml(xml);
-            if (arquivos.salvar) {
-                if (!await fs.existsSync(arquivos.pastaEnvio))
-                    await fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
-                if (!await fs.existsSync(arquivos.pastaRetorno))
-                    await fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
-                if (!await fs.existsSync(arquivos.pastaXML))
-                    await fs.mkdirSync(arquivos.pastaXML, { recursive: true });
+            if (arquivos && arquivos.salvar) {
+                if (!fs.existsSync(arquivos.pastaEnvio))
+                    fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
+                if (!fs.existsSync(arquivos.pastaRetorno))
+                    fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
+                if (!fs.existsSync(arquivos.pastaXML))
+                    fs.mkdirSync(arquivos.pastaXML, { recursive: true });
                 if ((result.success == true) && (Object(result.data).retInutNFe.infInut.cStat == 102)) {
                     const filename = `${arquivos.pastaXML}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-procInutNFe.xml`;
                     const procEvento = {
@@ -60,13 +60,13 @@ class InutilizaProcessor {
                     Utils.removeSelfClosedFields(procEvento);
                     let xmlProcEvento = xmlHelper_1.XmlHelper.serializeXml(procEvento, 'retInutNFe');
                     xmlProcEvento = xmlProcEvento.replace('[XML]', xml);
-                    await fs.writeFileSync(filename, xmlProcEvento);
+                    fs.writeFileSync(filename, xmlProcEvento);
                 }
                 else {
                     const filenameEnvio = `${arquivos.pastaEnvio}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-inutNFe.xml`;
                     const filenameRetorno = `${arquivos.pastaRetorno}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-retInutNFe.xml`;
-                    await fs.writeFileSync(filenameEnvio, result.xml_enviado);
-                    await fs.writeFileSync(filenameRetorno, result.xml_recebido);
+                    fs.writeFileSync(filenameEnvio, result.xml_enviado);
+                    fs.writeFileSync(filenameRetorno, result.xml_recebido);
                 }
             }
         }

--- a/lib/factory/processor/nfeProcessor2.d.ts
+++ b/lib/factory/processor/nfeProcessor2.d.ts
@@ -16,7 +16,7 @@ export declare class NFeProcessor {
      * @param documento Array de documentos modelo 55 ou 1 documento modelo 65
      */
     processarDocumento(documento: NFeDocumento | NFCeDocumento): Promise<RetornoProcessamentoNF>;
-    executar(documento: NFeDocumento | NFCeDocumento, assincrono?: boolean): Promise<RetornoProcessamentoNF>;
+    executar(documento: NFeDocumento | NFCeDocumento): Promise<RetornoProcessamentoNF>;
     inutilizarNumeracao(dados: Inutilizar): Promise<any>;
     gerarEvento(evento: Evento): Promise<any>;
 }

--- a/lib/factory/processor/nfeProcessor2.js
+++ b/lib/factory/processor/nfeProcessor2.js
@@ -47,8 +47,8 @@ class NFeProcessor {
         let result = await this.executar(documento);
         return result;
     }
-    async executar(documento, assincrono = false) {
-        const { arquivos } = this.configuracoes;
+    async executar(documento) {
+        const { arquivos, geral } = this.configuracoes;
         let result = {};
         try {
             result = await this.enviaProcessor.executar(documento);
@@ -57,7 +57,7 @@ class NFeProcessor {
             let cStat = '';
             if (result.envioNF && result.envioNF.data) {
                 const data = Object(result.envioNF.data);
-                if (data.retEnviNFe) {
+                if (data.retEnviNFe && geral.modelo == '55') {
                     retEnviNFe = data.retEnviNFe;
                     const recibo = retEnviNFe.infRec.nRec;
                     result.consultaProc = await this.retornoProcessor.executar(recibo);
@@ -69,13 +69,13 @@ class NFeProcessor {
                         result.confirmada = true;
                         result.success = true;
                     }
-                if (arquivos.salvar) {
-                    if (!await fs.existsSync(arquivos.pastaEnvio))
-                        await fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
-                    if (!await fs.existsSync(arquivos.pastaRetorno))
-                        await fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
-                    if (!await fs.existsSync(arquivos.pastaXML))
-                        await fs.mkdirSync(arquivos.pastaXML, { recursive: true });
+                if (arquivos && arquivos.salvar) {
+                    if (!fs.existsSync(arquivos.pastaEnvio))
+                        fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
+                    if (!fs.existsSync(arquivos.pastaRetorno))
+                        fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
+                    if (!fs.existsSync(arquivos.pastaXML))
+                        fs.mkdirSync(arquivos.pastaXML, { recursive: true });
                     if ((result.success == true) && (retConsReciNFe.cStat == '104')) {
                         const filename = `${arquivos.pastaXML}${retConsReciNFe.protNFe.infProt.chNFe}-procNFe.xml`;
                         const nfe_enviada = Object(xmlHelper_1.XmlHelper.deserializeXml(result.envioNF.xml_enviado, { explicitArray: false }));
@@ -86,17 +86,17 @@ class NFeProcessor {
                         };
                         Utils.removeSelfClosedFields(nfeProc);
                         let xmlNfeProc = xmlHelper_1.XmlHelper.serializeXml(nfeProc, 'nfeProc');
-                        await fs.writeFileSync(filename, xmlNfeProc);
+                        fs.writeFileSync(filename, xmlNfeProc);
                     }
                     else {
                         const filenameEnvio = `${arquivos.pastaEnvio}${retEnviNFe.infRec.nRec}-enviNFe.xml`;
                         const filenameRetorno = `${arquivos.pastaRetorno}${retEnviNFe.infRec.nRec}-retEnviNFe.xml`;
-                        await fs.writeFileSync(filenameEnvio, result.envioNF.xml_enviado);
-                        await fs.writeFileSync(filenameRetorno, result.envioNF.xml_recebido);
+                        fs.writeFileSync(filenameEnvio, result.envioNF.xml_enviado);
+                        fs.writeFileSync(filenameRetorno, result.envioNF.xml_recebido);
                         const filenameConsultaEnvio = `${arquivos.pastaEnvio}${retConsReciNFe.nRec}-consReciNFe.xml`;
                         const filenameConsultaRetorno = `${arquivos.pastaRetorno}${retConsReciNFe.nRec}-retConsReciNFe.xml`;
-                        await fs.writeFileSync(filenameConsultaEnvio, result.consultaProc.xml_enviado);
-                        await fs.writeFileSync(filenameConsultaRetorno, result.consultaProc.xml_recebido);
+                        fs.writeFileSync(filenameConsultaEnvio, result.consultaProc.xml_enviado);
+                        fs.writeFileSync(filenameConsultaRetorno, result.consultaProc.xml_recebido);
                     }
                 }
             }

--- a/src/factory/processor/enviaProcessor.ts
+++ b/src/factory/processor/enviaProcessor.ts
@@ -522,14 +522,14 @@ export class EnviaProcessor {
     private getDetImposto(imposto: Imposto, modelo: string, cfop: string) {
         let detImposto = <schema.TNFeInfNFeDetImposto>{
             vTotTrib: imposto.valorAproximadoTributos,
-            ICMS: [this.getImpostoIcms(imposto.icms)],
-            PIS: [this.getImpostoPIS(imposto.pis, modelo)],
-            COFINS: [this.getImpostoCOFINS(imposto.cofins, modelo)],
-            PISST: [this.getImpostoPISST(imposto.pisst)],
-            COFINSST: [this.getImpostoCOFINSST(imposto.cofinsst)],
-            IPI: [this.getImpostoIPI(imposto.ipi, modelo)],
-            II: [this.getImpostoII(imposto.ii, cfop)],
-            ICMSUFDest: [this.getIcmsUfDest(imposto.icmsUfDest)],
+            ICMS: imposto.icms ? [this.getImpostoIcms(imposto.icms)] : [],
+            PIS: imposto.pis ? [this.getImpostoPIS(imposto.pis, modelo)] : [],
+            COFINS: imposto.cofins ? [this.getImpostoCOFINS(imposto.cofins, modelo)] : [],
+            PISST: imposto.pisst ? [this.getImpostoPISST(imposto.pisst)] : [],
+            COFINSST: imposto.cofinsst ? [this.getImpostoCOFINSST(imposto.cofinsst)] : [],
+            IPI: imposto.ipi ? [this.getImpostoIPI(imposto.ipi, modelo)] : [],
+            II: imposto.ii ? [this.getImpostoII(imposto.ii, cfop)] : [],
+            ICMSUFDest: imposto.icmsUfDest ? [this.getIcmsUfDest(imposto.icmsUfDest)] : [],
             ISSQN: '',
         };
 

--- a/src/factory/processor/inutilizaProcessor.ts
+++ b/src/factory/processor/inutilizaProcessor.ts
@@ -48,10 +48,10 @@ export class InutilizaProcessor {
             const xml = this.gerarXml(dados);
             result = await this.transmitirXml(xml);
 
-            if (arquivos.salvar) {
-                if (! await fs.existsSync(arquivos.pastaEnvio)) await fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
-                if (! await fs.existsSync(arquivos.pastaRetorno)) await fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
-                if (!await fs.existsSync(arquivos.pastaXML)) await fs.mkdirSync(arquivos.pastaXML, { recursive: true });
+            if (arquivos && arquivos.salvar) {
+                if (!fs.existsSync(arquivos.pastaEnvio)) fs.mkdirSync(arquivos.pastaEnvio, { recursive: true });
+                if (!fs.existsSync(arquivos.pastaRetorno)) fs.mkdirSync(arquivos.pastaRetorno, { recursive: true });
+                if (!fs.existsSync(arquivos.pastaXML)) fs.mkdirSync(arquivos.pastaXML, { recursive: true });
                 
                 if ((result.success == true) && (Object(result.data).retInutNFe.infInut.cStat == 102)) {
                     const filename = `${arquivos.pastaXML}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-procInutNFe.xml`;
@@ -66,13 +66,13 @@ export class InutilizaProcessor {
                     let xmlProcEvento = XmlHelper.serializeXml(procEvento, 'retInutNFe');
                     xmlProcEvento = xmlProcEvento.replace('[XML]', xml);
 
-                    await fs.writeFileSync(filename, xmlProcEvento);
+                    fs.writeFileSync(filename, xmlProcEvento);
                 } else {
                     const filenameEnvio = `${arquivos.pastaEnvio}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-inutNFe.xml`;
                     const filenameRetorno = `${arquivos.pastaRetorno}${dados.ano}${dados.modelo}${dados.serie}${dados.numeroInicial}${dados.numeroFinal}-retInutNFe.xml`;
 
-                    await fs.writeFileSync(filenameEnvio, result.xml_enviado);
-                    await fs.writeFileSync(filenameRetorno, result.xml_recebido);
+                    fs.writeFileSync(filenameEnvio, result.xml_enviado);
+                    fs.writeFileSync(filenameRetorno, result.xml_recebido);
                 }
             }
         } catch (ex) {


### PR DESCRIPTION
A chamada de Inutlização não funcionaval, quebrando quando o documento era 65, nfce.

Adicionei um tratativa para o trecho em que ocorria o erro, junto com outras revisões no código.

Também adicionei demais endpoints para o serviço de inutilização. Poderia colocar o diretório /lib no gitignore também, não sei porque está sendo versionado..