### PR TITLE
Force na versao do xml2js e seu typing. Resolves #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run build && node test.js",
     "build": "tsc",
     "cxsd": "cxsd",
-    "dev":"ts-node-dev --respawn ./src/index.ts"
+    "dev": "ts-node-dev --respawn ./src/index.ts"
   },
   "repository": {
     "type": "git",
@@ -42,11 +42,11 @@
     "request": "^2.88.0",
     "sha1": "^1.1.1",
     "xml-crypto": "^1.2.0",
-    "xml2js": "^0.4.19"
+    "xml2js": "0.4.19"
   },
   "devDependencies": {
+    "@types/xml2js": "0.4.3",
     "@types/request": "^2.48.1",
-    "@types/xml2js": "^0.4.3",
     "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.1.6"
   }


### PR DESCRIPTION
A versao do xml2js estava dessincronizada com a versao do seu typing (em funçao de usar notaçao de versao "nao especifica"), o que causava um erro ao realizar o build.
A soluçao proposta foi fixar tanto a dependencia xml2js quanto a typings/xml2js.