### PR TITLE
Novas Variações de Certificado

### DIFF
--- a/lib/factory/interface/nfe/index.d.ts
+++ b/lib/factory/interface/nfe/index.d.ts
@@ -379,6 +379,11 @@ export interface Certificado {
     key: any;
     pfx: any;
     password: string;
+    opcoes?: OpcoesCertificado;
+}
+export interface OpcoesCertificado {
+    stringfyPassphrase?: boolean;
+    removeRejectUnauthorized?: boolean;
 }
 export declare function fromJsonixObj<T>(json: any): T;
 export interface Geral {

--- a/lib/factory/webservices/webserviceHelper.js
+++ b/lib/factory/webservices/webserviceHelper.js
@@ -73,11 +73,25 @@ class WebServiceHelper {
         return result;
     }
     static buildCertAgentOpt(cert) {
-        return {
-            rejectUnauthorized: (cert.rejectUnauthorized === undefined) ? true : cert.rejectUnauthorized,
-            pfx: cert.pfx,
-            passphrase: cert.password
-        };
+        const certAgentOpt = {};
+        if (cert.opcoes.stringfyPassphrase) {
+            certAgentOpt.passphrase = cert.password.toString();
+        }
+        else
+            (certAgentOpt.passphrase = cert.password);
+        if (!cert.opcoes.removeRejectUnauthorized) {
+            certAgentOpt.rejectUnauthorized = (cert.rejectUnauthorized === undefined) ? true : cert.rejectUnauthorized;
+        }
+        if (cert.pfx) {
+            certAgentOpt.pfx = cert.pfx;
+        }
+        if (cert.pem) {
+            certAgentOpt.cert = cert.pem;
+        }
+        if (cert.key) {
+            certAgentOpt.key = cert.key;
+        }
+        return certAgentOpt;
     }
     static async makeSoapRequest(xml, cert, soap, proxy) {
         let result = { xml_enviado: xml };

--- a/src/factory/interface/nfe/index.ts
+++ b/src/factory/interface/nfe/index.ts
@@ -429,6 +429,12 @@ export interface Certificado {
     key: any;
     pfx: any;
     password: string;
+    opcoes?: OpcoesCertificado;
+}
+
+export interface OpcoesCertificado {
+    stringfyPassphrase?: boolean;
+    removeRejectUnauthorized?: boolean;
 }
 
 export function fromJsonixObj<T>(json: any): T {

--- a/src/factory/webservices/webserviceHelper.ts
+++ b/src/factory/webservices/webserviceHelper.ts
@@ -101,11 +101,20 @@ export abstract class WebServiceHelper {
     }
 
     private static buildCertAgentOpt(cert: any) {
-        return {
-            rejectUnauthorized: (cert.rejectUnauthorized === undefined) ? true : cert.rejectUnauthorized,
-            pfx: cert.pfx,
-            passphrase: cert.password
+        const certAgentOpt:any = {}
+
+        if (cert.opcoes.stringfyPassphrase) {certAgentOpt.passphrase = cert.password.toString()}
+        else (certAgentOpt.passphrase = cert.password)
+
+        if (!cert.opcoes.removeRejectUnauthorized) {
+            certAgentOpt.rejectUnauthorized = (cert.rejectUnauthorized === undefined) ? true : cert.rejectUnauthorized
         }
+
+        if (cert.pfx) {certAgentOpt.pfx = cert.pfx}
+        if (cert.pem) {certAgentOpt.cert = cert.pem}
+        if (cert.key) {certAgentOpt.key = cert.key}
+
+        return certAgentOpt
     }
 
     public static async makeSoapRequest(xml: string, cert: any, soap: any, proxy?: WebProxy) {


### PR DESCRIPTION
Criado o campo `opcoes` na interface do Certificado possibilitando a tramissão do passphrase como string e a remoção do rejectUnauthorized. Ambos são opcionais.

Também criada a possibilidade de outros tipos de dados de certificado além de pfx caso eles existam no objeto recebido.